### PR TITLE
First step of bugfixes after demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/ScrappyCocco/ScrapEngine.svg?branch=master)](https://travis-ci.org/ScrappyCocco/ScrapEngine)
 
 # Description
-I have always been passionate about game development and rendering, and i wanted to go deeper into it. With the arrival of Vulkan, i thought it was a good time to start learning how a game engine works. The development of his game engine started on July 2018, and at the beginning of August 2018 it was able to render the basic triangle. Since then i had to slow down for a few months because of University and its projects, but on August 2019 this repository has been made public.
+I have always been passionate about game development and rendering, and i wanted to go deeper into it. With the arrival of Vulkan, i thought it was a good time to start learning how a game engine works. The development of his game engine started on July 2018, and at the beginning of August 2018 it was able to render the basic triangle. Since then i had to slow down for a few months because of University and its projects, but on August 2019 this repository has been made public with the release of the first working small game tagged as [demo 1](https://github.com/ScrappyCocco/ScrapEngine/releases/tag/demo_1).
 
 I followed mostly [Alexander Vulkan tutorial](https://vulkan-tutorial.com/) and [SaschaWillems Vulkan examples](https://github.com/SaschaWillems/Vulkan) to understand the basics and to develop it.
 

--- a/ScrapEngine/ScrapEngine/Engine/LogicCore/Manager/LogicManager.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/LogicCore/Manager/LogicManager.cpp
@@ -22,9 +22,14 @@ void ScrapEngine::Core::LogicManager::un_register_game_object(SGameObject* input
 	                                                         input_game_object);
 	if (element != registered_game_objects_.end())
 	{
-		delete *element;
+		delete_game_object(*element);
 		registered_game_objects_.erase(element);
 	}
+}
+
+void ScrapEngine::Core::LogicManager::delete_game_object(SGameObject* input_game_object)
+{
+	delete input_game_object;
 }
 
 void ScrapEngine::Core::LogicManager::execute_game_objects_start_event()

--- a/ScrapEngine/ScrapEngine/Engine/LogicCore/Manager/LogicManager.h
+++ b/ScrapEngine/ScrapEngine/Engine/LogicCore/Manager/LogicManager.h
@@ -16,6 +16,7 @@ namespace ScrapEngine
 
 			SGameObject* register_game_object(SGameObject* input_game_object);
 			void un_register_game_object(SGameObject* input_game_object);
+			void delete_game_object(SGameObject* input_game_object);
 
 			//Events
 			void execute_game_objects_start_event();

--- a/ScrapEngine/ScrapEngine/Engine/LogicCore/Manager/LogicManagerView.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/LogicCore/Manager/LogicManagerView.cpp
@@ -36,6 +36,11 @@ void ScrapEngine::Core::LogicManagerView::un_register_game_object(
 	logic_manager_ref_->un_register_game_object(input_game_object);
 }
 
+void ScrapEngine::Core::LogicManagerView::delete_game_object(SGameObject* input_game_object) const
+{
+	logic_manager_ref_->delete_game_object(input_game_object);
+}
+
 ScrapEngine::Core::ComponentsManager* ScrapEngine::Core::LogicManagerView::get_components_manager() const
 {
 	return component_manager_;

--- a/ScrapEngine/ScrapEngine/Engine/LogicCore/Manager/LogicManagerView.h
+++ b/ScrapEngine/ScrapEngine/Engine/LogicCore/Manager/LogicManagerView.h
@@ -24,7 +24,10 @@ namespace ScrapEngine
 			void set_audio_manager(Audio::AudioManager* audio_manager) const;
 
 			SGameObject* register_game_object(SGameObject* input_game_object) const;
+			//WARNING un-registering an object also delete it!
 			void un_register_game_object(SGameObject* input_game_object) const;
+			void delete_game_object(SGameObject* input_game_object) const;
+
 			ComponentsManager* get_components_manager() const;
 			SceneManager* get_scene_manager() const;
 		};

--- a/ScrapEngine/ScrapEngine/Engine/Manager/EngineManager.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/Manager/EngineManager.cpp
@@ -3,8 +3,10 @@
 #include <Engine/Debug/DebugLog.h>
 #include <Engine/Input/Gui/GuiInput.h>
 
-ScrapEngine::Manager::EngineManager::EngineManager(const std::string& app_name, const int app_version, const uint32_t window_width,
-                                                   const uint32_t window_height, const bool fullscreen, const bool vsync)
+ScrapEngine::Manager::EngineManager::EngineManager(const std::string& app_name, const int app_version,
+                                                   const uint32_t window_width,
+                                                   const uint32_t window_height, const bool fullscreen,
+                                                   const bool vsync)
 	: received_base_game_info_(app_name, app_version, window_width, window_height, fullscreen, vsync)
 {
 	initialize_engine();
@@ -82,8 +84,8 @@ void ScrapEngine::Manager::EngineManager::main_game_loop()
 	while (!window_ref->check_window_should_close())
 	{
 		//Compute frame delta time
-		const float time = std::chrono::duration<float, std::chrono::seconds::period>(current_time - start_time).
-			count();
+		const float time = std::chrono::duration<float, std::chrono::seconds::period>
+			(current_time - start_time).count();
 		//Execute objects update()
 		scrap_logic_manager_->execute_game_objects_update_event(time);
 		//Gui data update

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/BaseCommandBuffer.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/BaseCommandBuffer.cpp
@@ -17,6 +17,14 @@ void ScrapEngine::Render::BaseCommandBuffer::close_command_buffer()
 	}
 }
 
+void ScrapEngine::Render::BaseCommandBuffer::reset_command_buffer()
+{
+	for (auto& command_buffer : command_buffers_)
+	{
+		command_buffer.reset(vk::CommandBufferResetFlags());
+	}
+}
+
 void ScrapEngine::Render::BaseCommandBuffer::free_command_buffers()
 {
 	if (!command_buffers_.empty())

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/BaseCommandBuffer.h
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/BaseCommandBuffer.h
@@ -21,6 +21,8 @@ namespace ScrapEngine
 
 			void close_command_buffer();
 
+			void reset_command_buffer();
+
 			void free_command_buffers();
 
 			const std::vector<vk::CommandBuffer>* get_command_buffers_vector() const;

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/GuiCommandBuffer/GuiCommandBuffer.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/GuiCommandBuffer/GuiCommandBuffer.cpp
@@ -2,21 +2,11 @@
 #include <Engine/Rendering/Device/VulkanDevice.h>
 #include <imgui.h>
 
-ScrapEngine::Render::GuiCommandBuffer::GuiCommandBuffer(BaseRenderPass* render_pass)
+ScrapEngine::Render::GuiCommandBuffer::GuiCommandBuffer(BaseRenderPass* render_pass, VulkanCommandPool* command_pool)
 	: render_pass_ref_(render_pass)
-{
-}
-
-void ScrapEngine::Render::GuiCommandBuffer::init_command_buffer(
-	VulkanFrameBuffer* swap_chain_frame_buffer,
-	vk::Extent2D* input_swap_chain_extent_ref,
-	VulkanCommandPool* command_pool,
-	const uint32_t current_image)
 {
 	command_pool_ref_ = command_pool;
 
-	const std::vector<vk::Framebuffer>* swap_chain_framebuffers = swap_chain_frame_buffer->
-		get_swap_chain_framebuffers_vector();
 	//Optimize the GuiCommandBuffer generating only 1 command buffer instead of 3
 	//This because the GuiCommandBuffer is rebuilt every frame
 	//So it has no sense to allocate and build 2 unused command buffers
@@ -33,6 +23,15 @@ void ScrapEngine::Render::GuiCommandBuffer::init_command_buffer(
 	{
 		throw std::runtime_error("[VulkanCommandBuffer] Failed to allocate command buffers!");
 	}
+}
+
+void ScrapEngine::Render::GuiCommandBuffer::init_command_buffer(
+	VulkanFrameBuffer* swap_chain_frame_buffer,
+	vk::Extent2D* input_swap_chain_extent_ref,
+	const uint32_t current_image)
+{
+	const std::vector<vk::Framebuffer>* swap_chain_framebuffers = swap_chain_frame_buffer->
+		get_swap_chain_framebuffers_vector();
 
 	for (auto& command_buffer : command_buffers_)
 	{

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/GuiCommandBuffer/GuiCommandBuffer.h
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/GuiCommandBuffer/GuiCommandBuffer.h
@@ -15,13 +15,12 @@ namespace ScrapEngine
 		private:
 			BaseRenderPass* render_pass_ref_ = nullptr;
 		public:
-			explicit GuiCommandBuffer(BaseRenderPass* render_pass);
+			explicit GuiCommandBuffer(BaseRenderPass* render_pass, VulkanCommandPool* command_pool);
 
 			~GuiCommandBuffer() = default;
 
 			void init_command_buffer(VulkanFrameBuffer* swap_chain_frame_buffer,
 			                         vk::Extent2D* input_swap_chain_extent_ref,
-			                         VulkanCommandPool* command_pool,
 			                         uint32_t current_image);
 
 			void load_ui(VulkanImGui* gui);

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/StandardCommandBuffer/StandardCommandBuffer.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/StandardCommandBuffer/StandardCommandBuffer.cpp
@@ -2,16 +2,12 @@
 #include <Engine/Rendering/RenderPass/StandardRenderPass/StandardRenderPass.h>
 #include <Engine/Rendering/Device/VulkanDevice.h>
 
-void ScrapEngine::Render::StandardCommandBuffer::init_command_buffer(
-	VulkanFrameBuffer* swap_chain_frame_buffer,
-	vk::Extent2D* input_swap_chain_extent_ref,
-	VulkanCommandPool* command_pool)
+ScrapEngine::Render::StandardCommandBuffer::StandardCommandBuffer(VulkanCommandPool* command_pool,
+                                                                  const int16_t cb_size)
 {
 	command_pool_ref_ = command_pool;
 
-	const std::vector<vk::Framebuffer>* swap_chain_framebuffers = swap_chain_frame_buffer->
-		get_swap_chain_framebuffers_vector();
-	command_buffers_.resize(swap_chain_framebuffers->size());
+	command_buffers_.resize(cb_size);
 
 	vk::CommandBufferAllocateInfo alloc_info(
 		*command_pool_ref_->get_command_pool(),
@@ -24,7 +20,11 @@ void ScrapEngine::Render::StandardCommandBuffer::init_command_buffer(
 	{
 		throw std::runtime_error("[VulkanCommandBuffer] Failed to allocate command buffers!");
 	}
+}
 
+void ScrapEngine::Render::StandardCommandBuffer::init_command_buffer(
+	vk::Extent2D* input_swap_chain_extent_ref, VulkanFrameBuffer* swap_chain_frame_buffer)
+{
 	for (size_t i = 0; i < command_buffers_.size(); i++)
 	{
 		vk::CommandBufferBeginInfo begin_info(vk::CommandBufferUsageFlagBits::eSimultaneousUse);
@@ -34,6 +34,8 @@ void ScrapEngine::Render::StandardCommandBuffer::init_command_buffer(
 			throw std::runtime_error("[VulkanCommandBuffer] Failed to begin recording command buffer!");
 		}
 
+		const std::vector<vk::Framebuffer>* swap_chain_framebuffers = swap_chain_frame_buffer->
+			get_swap_chain_framebuffers_vector();
 		render_pass_info_ = vk::RenderPassBeginInfo(
 			*StandardRenderPass::get_instance()->get_render_pass(),
 			(*swap_chain_framebuffers)[i],

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/StandardCommandBuffer/StandardCommandBuffer.h
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/StandardCommandBuffer/StandardCommandBuffer.h
@@ -15,13 +15,12 @@ namespace ScrapEngine
 		private:
 			Camera* current_camera_ = nullptr;
 		public:
-			StandardCommandBuffer() = default;
+			explicit StandardCommandBuffer(VulkanCommandPool* command_pool, int16_t size);
 
 			~StandardCommandBuffer() = default;
 
-			void init_command_buffer(VulkanFrameBuffer* swap_chain_frame_buffer,
-			                         vk::Extent2D* input_swap_chain_extent_ref,
-			                         VulkanCommandPool* command_pool);
+			void init_command_buffer(vk::Extent2D* input_swap_chain_extent_ref,
+			                         VulkanFrameBuffer* swap_chain_frame_buffer);
 			void init_current_camera(Camera* current_camera);
 
 			void load_skybox(VulkanSkyboxInstance* skybox_ref);

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/StandardCommandBuffer/StandardCommandBuffer.h
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Buffer/CommandBuffer/StandardCommandBuffer/StandardCommandBuffer.h
@@ -15,7 +15,7 @@ namespace ScrapEngine
 		private:
 			Camera* current_camera_ = nullptr;
 		public:
-			explicit StandardCommandBuffer(VulkanCommandPool* command_pool, int16_t size);
+			explicit StandardCommandBuffer(VulkanCommandPool* command_pool, int16_t cb_size);
 
 			~StandardCommandBuffer() = default;
 

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/CommandPool/VulkanCommandPool.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/CommandPool/VulkanCommandPool.cpp
@@ -3,9 +3,10 @@
 #include <Engine/Rendering/Device/VulkanDevice.h>
 //Class
 
-void ScrapEngine::Render::VulkanCommandPool::init(const BaseQueue::QueueFamilyIndices queue_family_indices)
+void ScrapEngine::Render::VulkanCommandPool::init(const BaseQueue::QueueFamilyIndices queue_family_indices,
+                                                  const vk::CommandPoolCreateFlags& flags)
 {
-	vk::CommandPoolCreateInfo pool_info(vk::CommandPoolCreateFlags(), queue_family_indices.graphics_family);
+	vk::CommandPoolCreateInfo pool_info(flags, queue_family_indices.graphics_family);
 
 	if (VulkanDevice::get_instance()->get_logical_device()->createCommandPool(&pool_info, nullptr, &command_pool_)
 		!= vk::Result::eSuccess)

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/CommandPool/VulkanCommandPool.h
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/CommandPool/VulkanCommandPool.h
@@ -16,7 +16,7 @@ namespace ScrapEngine
 			VulkanCommandPool() = default;
 		public:
 			//Method used to init the class with parameters because the constructor is private
-			void init(BaseQueue::QueueFamilyIndices queue_family_indices);
+			void init(BaseQueue::QueueFamilyIndices queue_family_indices, const vk::CommandPoolCreateFlags& flags = vk::CommandPoolCreateFlags());
 
 			virtual ~VulkanCommandPool() = 0;
 

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Manager/RenderManager.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Manager/RenderManager.cpp
@@ -502,11 +502,11 @@ void ScrapEngine::Render::RenderManager::draw_loading_frame()
 
 	//Submit
 	submit_info.setCommandBufferCount(2);
-	std::vector<vk::CommandBuffer> command_buffers;
-	command_buffers.push_back(
-		(*command_buffers_[command_buffer_flip_flop_].command_buffer->get_command_buffers_vector())[image_index_]);
-	command_buffers.push_back((*gui_command_buffer_->get_command_buffers_vector())[0]);
-	submit_info.setPCommandBuffers(command_buffers.data());
+	vk::CommandBuffer command_buffers[2];
+	command_buffers[0] =
+		(*command_buffers_[command_buffer_flip_flop_].command_buffer->get_command_buffers_vector())[image_index_];
+	command_buffers[1] = (*gui_command_buffer_->get_command_buffers_vector())[0];
+	submit_info.setPCommandBuffers(&command_buffers[0]);
 
 	VulkanDevice::get_instance()->get_logical_device()->resetFences(1, &(*in_flight_fences_ref_)[current_frame_]);
 
@@ -588,13 +588,13 @@ void ScrapEngine::Render::RenderManager::draw_frame()
 	wait_gui_commandbuffer_task();
 	//Submit
 	submit_info.setCommandBufferCount(2);
-	std::vector<vk::CommandBuffer> command_buffers;
+	vk::CommandBuffer command_buffers[2];
 	//Push main command buffer
-	command_buffers.push_back(
-		(*command_buffers_[command_buffer_flip_flop_].command_buffer->get_command_buffers_vector())[image_index_]);
+	command_buffers[0] =
+		(*command_buffers_[command_buffer_flip_flop_].command_buffer->get_command_buffers_vector())[image_index_];
 	//Push GUI command buffer
-	command_buffers.push_back((*gui_command_buffer_->get_command_buffers_vector())[0]);
-	submit_info.setPCommandBuffers(command_buffers.data());
+	command_buffers[1] = (*gui_command_buffer_->get_command_buffers_vector())[0];
+	submit_info.setPCommandBuffers(&command_buffers[0]);
 
 	vk::Semaphore signal_semaphores[] = {(*render_finished_semaphores_ref_)[current_frame_]};
 	submit_info.setSignalSemaphoreCount(1);

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Manager/RenderManager.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Manager/RenderManager.cpp
@@ -388,8 +388,6 @@ void ScrapEngine::Render::RenderManager::create_command_buffer(const bool flip_f
 		command_buffers_[index].command_buffer->load_skybox(skybox_);
 	}
 	//3d models
-	//Remove deleted meshes
-	cleanup_meshes();
 	//Now render the meshes
 	for (auto mesh : loaded_models_)
 	{
@@ -544,7 +542,7 @@ void ScrapEngine::Render::RenderManager::draw_frame()
 	{
 		throw std::runtime_error("RenderManager: Failed to acquire swap chain image!");
 	}
-	//Before updating the command buffer wait for the cleanup task to end
+	//Before updating the uniform buffer wait for the cleanup task to end
 	wait_cleanup_task();
 	//Update objects and uniform buffers
 	//Camera

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Manager/RenderManager.h
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Manager/RenderManager.h
@@ -35,9 +35,14 @@ namespace ScrapEngine
 			VulkanSwapChain* vulkan_render_swap_chain_ = nullptr;
 			VulkanImageView* vulkan_render_image_view_ = nullptr;
 			VulkanFrameBuffer* vulkan_render_frame_buffer_ = nullptr;
+			
 			VulkanCommandPool* vulkan_render_command_pool_ = nullptr;
+			VulkanCommandPool* command_buffer_command_pool_ = nullptr;
+			VulkanCommandPool* gui_buffer_command_pool_ = nullptr;
+			
 			BaseQueue* vulkan_graphics_queue_ = nullptr;
 			BaseQueue* vulkan_presentation_queue_ = nullptr;
+			
 			VulkanSemaphoresManager* vulkan_render_semaphores_ = nullptr;
 			VulkanSurface* vulkan_window_surface_ = nullptr;
 			VulkanDepthResources* vulkan_render_depth_ = nullptr;

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Model/SkyboxInstance/VulkanSkyboxInstance.cpp
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Model/SkyboxInstance/VulkanSkyboxInstance.cpp
@@ -28,6 +28,7 @@ ScrapEngine::Render::VulkanSkyboxInstance::VulkanSkyboxInstance(const std::strin
 	}
 	mesh_buffers_ = VulkanModelBuffersPool::get_instance()->get_model_buffers(model_path, vulkan_render_model_);
 	skybox_transform_.set_position(Core::SVector3());
+	skybox_transform_updated_ = true;
 	skybox_transform_.set_scale(Core::SVector3(50, 50, 50));
 }
 
@@ -38,9 +39,10 @@ ScrapEngine::Render::VulkanSkyboxInstance::~VulkanSkyboxInstance()
 }
 
 void ScrapEngine::Render::VulkanSkyboxInstance::update_uniform_buffer(const uint32_t& current_image,
-                                                                      Camera* render_camera) const
+                                                                      Camera* render_camera)
 {
-	vulkan_render_uniform_buffer_->update_uniform_buffer(current_image, skybox_transform_, render_camera);
+	vulkan_render_uniform_buffer_->update_uniform_buffer(current_image, skybox_transform_, render_camera, skybox_transform_updated_);
+	skybox_transform_updated_ = false;
 }
 
 int ScrapEngine::Render::VulkanSkyboxInstance::get_cubemap_size() const
@@ -52,6 +54,7 @@ void ScrapEngine::Render::VulkanSkyboxInstance::set_cubemap_size(const unsigned 
 {
 	const float size = static_cast<float>(new_size);
 	skybox_transform_.set_scale(Core::SVector3(size, size, size));
+	skybox_transform_updated_ = true;
 }
 
 ScrapEngine::Render::UniformBuffer* ScrapEngine::Render::VulkanSkyboxInstance::get_vulkan_render_uniform_buffer() const

--- a/ScrapEngine/ScrapEngine/Engine/Rendering/Model/SkyboxInstance/VulkanSkyboxInstance.h
+++ b/ScrapEngine/ScrapEngine/Engine/Rendering/Model/SkyboxInstance/VulkanSkyboxInstance.h
@@ -23,14 +23,16 @@ namespace ScrapEngine
 					VertexBufferContainer*,
 					IndicesBufferContainer*>
 			>> mesh_buffers_;
+			
 			Core::STransform skybox_transform_;
+			bool skybox_transform_updated_ = false;
 		public:
 			VulkanSkyboxInstance(const std::string& vertex_shader_path, const std::string& fragment_shader_path,
 			                     const std::string& model_path, const std::array<std::string, 6>& texture_path,
 			                     VulkanSwapChain* swap_chain);
 			~VulkanSkyboxInstance();
 
-			void update_uniform_buffer(const uint32_t& current_image, Camera* render_camera) const;
+			void update_uniform_buffer(const uint32_t& current_image, Camera* render_camera);
 
 			int get_cubemap_size() const;
 			void set_cubemap_size(unsigned int new_size);

--- a/ScrapEngine/SimpleGame/GameObjects/WorldObjects/Coin.cpp
+++ b/ScrapEngine/SimpleGame/GameObjects/WorldObjects/Coin.cpp
@@ -52,6 +52,8 @@ void Coin::game_update(const float time)
 		//Delete trigger
 		component_manager_ref_->destroy_trigger_component(box_trigger_);
 		//Delete mesh
+		//REMEMBER, after this call the pointer is no longer valid and should not be used
+		//ALSO if the mesh is connected to a rigidbody, you must delete BOTH togheder to avoid errors
 		component_manager_ref_->destroy_mesh_component(mesh_);
 		//Delete this
 		logic_manager_view_->un_register_game_object(this);


### PR DESCRIPTION
* Command buffers no longer allocate memory on every init
* Vector moved with std::move instead of being copied every time
* The skybox doesn't update its trasform every frame since it's static